### PR TITLE
fix: Migrate away from synthetic accessors

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -11,7 +11,6 @@ public abstract class com/transferwise/sequencelayout/SequenceAdapter {
 }
 
 public final class com/transferwise/sequencelayout/SequenceLayout : android/widget/FrameLayout, com/transferwise/sequencelayout/SequenceStep$OnStepChangedListener {
-	public field _$_findViewCache Ljava/util/Map;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -27,7 +26,6 @@ public final class com/transferwise/sequencelayout/SequenceLayout : android/widg
 }
 
 public final class com/transferwise/sequencelayout/SequenceStep : android/widget/TableRow {
-	public field _$_findViewCache Ljava/util/Map;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun _$_clearFindViewByIdCache ()V
@@ -54,7 +52,6 @@ public abstract interface class com/transferwise/sequencelayout/SequenceStep$OnS
 }
 
 public final class com/transferwise/sequencelayout/SequenceStepDot : android/widget/FrameLayout {
-	public field _$_findViewCache Ljava/util/Map;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -14,8 +14,6 @@ public final class com/transferwise/sequencelayout/SequenceLayout : android/widg
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
-	public fun _$_clearFindViewByIdCache ()V
-	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public fun addView (Landroid/view/View;ILandroid/view/ViewGroup$LayoutParams;)V
 	public fun onStepChanged ()V
 	public final fun removeAllSteps ()V
@@ -28,8 +26,6 @@ public final class com/transferwise/sequencelayout/SequenceLayout : android/widg
 public final class com/transferwise/sequencelayout/SequenceStep : android/widget/TableRow {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-	public fun _$_clearFindViewByIdCache ()V
-	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public final fun getDotOffset ()I
 	public final fun getOnStepChangedListener$com_transferwise_sequencelayout_null_release ()Lcom/transferwise/sequencelayout/SequenceStep$OnStepChangedListener;
 	public final fun isActive ()Z
@@ -55,8 +51,6 @@ public final class com/transferwise/sequencelayout/SequenceStepDot : android/wid
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
-	public fun _$_clearFindViewByIdCache ()V
-	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public fun setActivated (Z)V
 	public final fun setDotBackground$com_transferwise_sequencelayout_null_release (II)V
 	public fun setEnabled (Z)V

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("kotlin-android-extensions")
     id("maven-publish")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")  version "0.5.0"
 }

--- a/library/src/main/java/com/transferwise/sequencelayout/SequenceStep.kt
+++ b/library/src/main/java/com/transferwise/sequencelayout/SequenceStep.kt
@@ -3,6 +3,7 @@ package com.transferwise.sequencelayout
 import android.content.Context
 import android.content.res.TypedArray
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.TableRow
 import android.widget.TextView
@@ -11,7 +12,6 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.core.view.doOnPreDraw
 import androidx.core.widget.TextViewCompat
-import kotlinx.android.synthetic.main.sequence_step.view.*
 import kotlin.math.max
 
 /**
@@ -45,8 +45,7 @@ import kotlin.math.max
  *
  * @see com.transferwise.sequencelayout.SequenceLayout
  */
-public class SequenceStep(context: Context?, attrs: AttributeSet?)
-    : TableRow(context, attrs) {
+public class SequenceStep(context: Context?, attrs: AttributeSet?) : TableRow(context, attrs) {
 
     public constructor(context: Context) : this(context, null)
 
@@ -54,16 +53,23 @@ public class SequenceStep(context: Context?, attrs: AttributeSet?)
     internal var onStepChangedListener: OnStepChangedListener? = null
 
     init {
-        View.inflate(context, R.layout.sequence_step, this)
+        LayoutInflater.from(getContext()).inflate(R.layout.sequence_step, this, true)
+    }
 
+    private val anchor = findViewById<TextView>(R.id.anchor)
+    private val title = findViewById<TextView>(R.id.title)
+    private val subtitle = findViewById<TextView>(R.id.subtitle)
+
+    init {
         clipToPadding = false
         clipChildren = false
 
         val attributes = getContext().theme.obtainStyledAttributes(
-                attrs,
-                R.styleable.SequenceStep,
-                0,
-                R.style.SequenceStep)
+            attrs,
+            R.styleable.SequenceStep,
+            0,
+            R.style.SequenceStep
+        )
 
         setupAnchor(attributes)
         setupAnchorWidth(attributes)
@@ -194,7 +200,10 @@ public class SequenceStep(context: Context?, attrs: AttributeSet?)
     }
 
     fun getDotOffset(): Int =
-            (max(getViewHeight(anchor), getViewHeight(title)) - 8.toPx()) / 2 //TODO dynamic dot height
+        (max(
+            getViewHeight(anchor),
+            getViewHeight(title)
+        ) - 8.toPx()) / 2 //TODO dynamic dot height
 
     private fun setupAnchor(attributes: TypedArray) {
         if (!attributes.hasValue(R.styleable.SequenceStep_anchor)) {
@@ -205,8 +214,18 @@ public class SequenceStep(context: Context?, attrs: AttributeSet?)
     }
 
     private fun setupAnchorWidth(attributes: TypedArray) {
-        setAnchorMinWidth(attributes.getDimensionPixelSize(R.styleable.SequenceStep_anchorMinWidth, 0))
-        setAnchorMaxWidth(attributes.getDimensionPixelSize(R.styleable.SequenceStep_anchorMaxWidth, Integer.MAX_VALUE))
+        setAnchorMinWidth(
+            attributes.getDimensionPixelSize(
+                R.styleable.SequenceStep_anchorMinWidth,
+                0
+            )
+        )
+        setAnchorMaxWidth(
+            attributes.getDimensionPixelSize(
+                R.styleable.SequenceStep_anchorMaxWidth,
+                Integer.MAX_VALUE
+            )
+        )
     }
 
     private fun setupSubtitle(attributes: TypedArray) {
@@ -227,19 +246,34 @@ public class SequenceStep(context: Context?, attrs: AttributeSet?)
 
     private fun setupTitleTextAppearance(attributes: TypedArray) {
         if (attributes.hasValue(R.styleable.SequenceStep_titleTextAppearance)) {
-            setTitleTextAppearance(attributes.getResourceId(R.styleable.SequenceStep_titleTextAppearance, 0))
+            setTitleTextAppearance(
+                attributes.getResourceId(
+                    R.styleable.SequenceStep_titleTextAppearance,
+                    0
+                )
+            )
         }
     }
 
     private fun setupSubtitleTextAppearance(attributes: TypedArray) {
         if (attributes.hasValue(R.styleable.SequenceStep_subtitleTextAppearance)) {
-            setSubtitleTextAppearance(attributes.getResourceId(R.styleable.SequenceStep_subtitleTextAppearance, 0))
+            setSubtitleTextAppearance(
+                attributes.getResourceId(
+                    R.styleable.SequenceStep_subtitleTextAppearance,
+                    0
+                )
+            )
         }
     }
 
     private fun setupAnchorTextAppearance(attributes: TypedArray) {
         if (attributes.hasValue(R.styleable.SequenceStep_anchorTextAppearance)) {
-            setAnchorTextAppearance(attributes.getResourceId(R.styleable.SequenceStep_anchorTextAppearance, 0))
+            setAnchorTextAppearance(
+                attributes.getResourceId(
+                    R.styleable.SequenceStep_anchorTextAppearance,
+                    0
+                )
+            )
         }
     }
 
@@ -258,11 +292,11 @@ public class SequenceStep(context: Context?, attrs: AttributeSet?)
     }
 
     private fun getViewHeight(view: View) =
-            if (view is TextView) {
-                ((view.lineHeight - view.lineSpacingExtra) / view.lineSpacingMultiplier).toInt()
-            } else {
-                view.measuredHeight
-            }
+        if (view is TextView) {
+            ((view.lineHeight - view.lineSpacingExtra) / view.lineSpacingMultiplier).toInt()
+        } else {
+            view.measuredHeight
+        }
 
     internal interface OnStepChangedListener {
         fun onStepChanged()

--- a/library/src/main/java/com/transferwise/sequencelayout/SequenceStepDot.kt
+++ b/library/src/main/java/com/transferwise/sequencelayout/SequenceStepDot.kt
@@ -11,12 +11,12 @@ import android.graphics.drawable.GradientDrawable.OVAL
 import android.graphics.drawable.StateListDrawable
 import androidx.annotation.ColorInt
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
-import kotlinx.android.synthetic.main.sequence_dot.view.*
 
-internal class SequenceStepDot(context: Context, attrs: AttributeSet?, defStyleAttr: Int)
-    : FrameLayout(context, attrs, defStyleAttr) {
+internal class SequenceStepDot(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+    FrameLayout(context, attrs, defStyleAttr) {
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
@@ -24,7 +24,13 @@ internal class SequenceStepDot(context: Context, attrs: AttributeSet?, defStyleA
     private var pulseAnimator: AnimatorSet? = null
 
     init {
-        View.inflate(getContext(), R.layout.sequence_dot, this)
+        LayoutInflater.from(getContext()).inflate(R.layout.sequence_dot, this, true)
+    }
+
+    private val dotView = findViewById<View>(R.id.dotView)
+    private val pulseView = findViewById<View>(R.id.pulseView)
+
+    init {
         isEnabled = false
     }
 
@@ -34,25 +40,25 @@ internal class SequenceStepDot(context: Context, attrs: AttributeSet?, defStyleA
             setExitFadeDuration(resources.getInteger(R.integer.sequence_step_duration))
 
             addState(intArrayOf(android.R.attr.state_activated),
-                    with(GradientDrawable()) {
-                        shape = OVAL
-                        setColor(color)
-                        this
-                    })
+                with(GradientDrawable()) {
+                    shape = OVAL
+                    setColor(color)
+                    this
+                })
             addState(intArrayOf(android.R.attr.state_enabled),
-                    with(GradientDrawable()) {
-                        shape = OVAL
-                        setColor(color)
-                        setStroke(1.toPx(), Color.TRANSPARENT)
-                        this
-                    })
+                with(GradientDrawable()) {
+                    shape = OVAL
+                    setColor(color)
+                    setStroke(1.toPx(), Color.TRANSPARENT)
+                    this
+                })
             addState(intArrayOf(),
-                    with(GradientDrawable()) {
-                        shape = OVAL
-                        setColor(progressBackgroundColor)
-                        setStroke(1.toPx(), Color.TRANSPARENT)
-                        this
-                    })
+                with(GradientDrawable()) {
+                    shape = OVAL
+                    setColor(progressBackgroundColor)
+                    setStroke(1.toPx(), Color.TRANSPARENT)
+                    this
+                })
             dotView.background = this
         }
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,6 +10,10 @@ android {
         targetSdkVersion(31)
         applicationId = "com.transferwise.sequencelayout.sample"
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Context

Remove kotlin synthetic view accessors and `kotlinx-extensions` and replace it with regular `findViewById`

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
