### PR TITLE
chore: Add stale bot to manage the Issues/PRs better

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Maintenance
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          close-issue-message: 'This issue has now been closed. Please raise a new Issue instead of re-opening existing ones, unless you believe this was closed by accident.'
+          days-before-issue-stale: 31
+          days-before-issue-close: 7
+          stale-issue-label: 'stale'
+          only-issue-labels: 'awaiting-feedback'
+          exempt-issue-labels: 'confirmed'
+
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          close-pr-message: 'This pull request has now been closed. If you want to continue working on it or you believe it has been closed by accident, feel free to re-open it.'
+          days-before-pr-stale: 31
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'work-in-progress,dependencies'
+          exempt-draft-pr: true


### PR DESCRIPTION
## Context

Add stale bot to manage the Issues/PRs better.

- Inactive Issues that are labeled with 'awaiting-feedback' will get marked as 'stale' after a period of time, then closed
- Inactive PRs that are not in draft, or labeled with 'work-in-progress' or 'dependencies' will get marked as 'stale' after a period of time, then closed
- Added dependabot support for GitHub Actions to keep our actions up-to-date

Our current labels are the following:
![image](https://user-images.githubusercontent.com/935897/142490662-727880cf-701c-4602-aa36-993d3e767acf.png)

We should go over the open Issues, reply to them and/or mark them accordingly!

The ones we are waiting for input should have **'awaiting-feedback'**. The rest should be triaged accordingly and closed.

Signed-off-by: Antal János Monori <antal.monori@transferwise.com>

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
